### PR TITLE
fix: github link in navbar

### DIFF
--- a/theme.config.js
+++ b/theme.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-anonymous-default-export */
 export default {
+  github: "https://github.com/fnapi/docs", // GitHub link in the navbar
   projectLink: "https://github.com/fnapi/docs", // GitHub link in the navbar
   docsRepositoryBase: "https://github.com/fnapi/docs", // base URL for the docs repository
   titleSuffix: " – FnApi",


### PR DESCRIPTION
The github link in the navbar goes to the wrong link

![image](https://user-images.githubusercontent.com/78015359/175782303-a3c8dfdf-152c-41d4-be7c-bd9fc16c7002.png)

It's tricky, even though the `projectLink` attribute is defined, it still leads to the wrong link

In the latest version they also use the `github` attribute

https://github.com/shuding/nextra/blob/e162f839a4967ce66345a57e9b43c30651fffb93/packages/nextra-theme-docs/src/navbar.tsx#L144-L159
